### PR TITLE
CI: Update checkout and upload-artifact steps to v2

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/cache@v2
         with:
@@ -40,7 +40,7 @@ jobs:
         run: tar -czf ct_website_${{ env.RELEASE_VERSION }}.tar.gz ./public
 
       - name: Upload release tar
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
             name: ct_website_${{ env.RELEASE_VERSION }}
             path: ct_website_${{ env.RELEASE_VERSION }}.tar.gz


### PR DESCRIPTION
Update checkout and upload-artifact steps to v2. Both are faster and better maintained than the v1 versions.