### PR TITLE
[Feature] Enable universal links

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,13 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "C2H38GV99H.nl.rijksoverheid.ctr",
+        "paths": [
+          "/app/*"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Enables “universal links” to be opened in the native iOS app instead of on the website. See also the [Apple developer documentation].(https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html)
