### PR TITLE
[Bugfix] Content and breadcrumb fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,13 +6,13 @@ collections:
     permalink: /:categories/:name/
   questions-in-app:
     output: true
-    permalink: in-app/:categories/:name/
+    permalink: /:categories/:name/
   questions-scanner:
     output: true
     permalink: /:categories/:name/
   questions-scanner-in-app:
     output: true
-    permalink: in-app/scanner/:categories/:name/
+    permalink: /:categories/:name/
   stories:
     output: false
   scanner-instructions:

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -10,14 +10,22 @@
     {{% assign start_crumb = '' %}}
     
     {% if forloop.first %}
-      <li class="breadcrumbs-item"> 
+    <li class="breadcrumbs-item"> 
+      {% if include.collection == 'questions-in-app' %} 
+        <a class="breadcrumbs" href="{{langSlug}}/faq-in-app">
+          {{ site.data.translations.faq[page.lang] }}</a>
+      {% elsif include.collection == 'questions-scanner-in-app' %}
+        <a class="breadcrumbs" href="{{langSlug}}/faq-scanner-in-app">
+          {{ site.data.translations.faq[page.lang] }}</a>
+      {% else %}
         <a class="breadcrumbs" href="{{langSlug}}">
-          {{ site.data.translations.layout-template-home[page.lang] }}
-        </a>
-        {% if forloop.last == false %}
-          <span class="icon icon-chevron-right"></span>
-        {% endif %}
-      </li> 
+          {{ site.data.translations.layout-template-home[page.lang] }}</a>
+      {% endif %}
+
+      {% if forloop.last == false %}
+        <span class="icon icon-chevron-right"></span>
+      {% endif %}
+    </li> 
     {% elsif forloop.last == false %} 
       {% if include.collection == 'questions-scanner' %} 
         <li class="breadcrumbs-item">

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -8,28 +8,31 @@
   <ul> 
   {% for crumb in crumbs offset: 1 %}
     {{% assign start_crumb = '' %}}
+    
     {% if forloop.first %}
-    <li class="breadcrumbs-item"> 
+      <li class="breadcrumbs-item"> 
         <a class="breadcrumbs" href="{{langSlug}}">
           {{ site.data.translations.layout-template-home[page.lang] }}
         </a>
         {% if forloop.last == false %}
           <span class="icon icon-chevron-right"></span>
         {% endif %}
-    </li> 
-    {% elsif forloop.last == false and include.collection == 'questions-scanner' %} 
-      <li class="breadcrumbs-item">
-        <a class="breadcrumbs" href="{{langSlug}}/faq-scanner">
-        {{ site.data.translations.faq[page.lang] | truncate: 40 }}</a>
-        <span class="icon icon-chevron-right"></span>
-      </li>
-    {% elsif forloop.last == false and include.collection == 'questions' %}
+      </li> 
+    {% elsif forloop.last == false %} 
+      {% if include.collection == 'questions-scanner' %} 
         <li class="breadcrumbs-item">
-          <a class="breadcrumbs" href="{{langSlug}}/faq">
-            {{ site.data.translations.faq[page.lang] | truncate: 40 }}</a>
+          <a class="breadcrumbs" href="{{langSlug}}/faq-scanner">
+          {{ site.data.translations.faq[page.lang] | truncate: 40 }}</a>
           <span class="icon icon-chevron-right"></span>
         </li>
-    {% else  %}
+      {% elsif include.collection == 'questions' %}
+          <li class="breadcrumbs-item">
+            <a class="breadcrumbs" href="{{langSlug}}/faq">
+              {{ site.data.translations.faq[page.lang] | truncate: 40 }}</a>
+            <span class="icon icon-chevron-right"></span>
+          </li>
+      {% endif %}
+    {% elsif forloop.last  %}
       <li class="breadcrumbs-item"> 
         {% if page.contentLang == 'en' %}
           <span class="breadcrumbs disabled" dir="ltr" lang="en" aria-current="page">{{ include.title | truncate: 40 }}</span>

--- a/_questions-in-app/en/1-hoe-werkt-de-coronacheck-app.md
+++ b/_questions-in-app/en/1-hoe-werkt-de-coronacheck-app.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true 
 ---

--- a/_questions-in-app/en/1-hoe-werkt-de-coronacheck-app.md
+++ b/_questions-in-app/en/1-hoe-werkt-de-coronacheck-app.md
@@ -6,8 +6,7 @@ title: How does the CoronaCheck app work?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true 
 ---

--- a/_questions-in-app/en/10-waarom-is-de-geldigheidsduur-van-een-testbewijs-40-uur.md
+++ b/_questions-in-app/en/10-waarom-is-de-geldigheidsduur-van-een-testbewijs-40-uur.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/10-waarom-is-de-geldigheidsduur-van-een-testbewijs-40-uur.md
+++ b/_questions-in-app/en/10-waarom-is-de-geldigheidsduur-van-een-testbewijs-40-uur.md
@@ -6,8 +6,7 @@ title: Why is a test declaration valid for 40 hours?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/11-werkt-coronacheck-op-mijn-telefoon.md
+++ b/_questions-in-app/en/11-werkt-coronacheck-op-mijn-telefoon.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/11-werkt-coronacheck-op-mijn-telefoon.md
+++ b/_questions-in-app/en/11-werkt-coronacheck-op-mijn-telefoon.md
@@ -6,8 +6,7 @@ title: Is the CoronaCheck app compatible with my phone?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/12-kan-ik-coronacheck-ook-gebruiken-in-het-buitenland.md
+++ b/_questions-in-app/en/12-kan-ik-coronacheck-ook-gebruiken-in-het-buitenland.md
@@ -6,8 +6,7 @@ title: Can I use the CoronaCheck app abroad?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/12-kan-ik-coronacheck-ook-gebruiken-in-het-buitenland.md
+++ b/_questions-in-app/en/12-kan-ik-coronacheck-ook-gebruiken-in-het-buitenland.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/13-de-app-zegt-dat-er-geen-negatief-testresultaat-gevonden-is-hoe-kan-dit.md
+++ b/_questions-in-app/en/13-de-app-zegt-dat-er-geen-negatief-testresultaat-gevonden-is-hoe-kan-dit.md
@@ -6,8 +6,7 @@ title: The app doesn't show a negative test result. Why?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 published: false

--- a/_questions-in-app/en/13-de-app-zegt-dat-er-geen-negatief-testresultaat-gevonden-is-hoe-kan-dit.md
+++ b/_questions-in-app/en/13-de-app-zegt-dat-er-geen-negatief-testresultaat-gevonden-is-hoe-kan-dit.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 published: false

--- a/_questions-in-app/en/14-mijn-qr-code-is-gescand-maar-geeft-een-rood-scherm-wat-moet-ik-doen.md
+++ b/_questions-in-app/en/14-mijn-qr-code-is-gescand-maar-geeft-een-rood-scherm-wat-moet-ik-doen.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/14-mijn-qr-code-is-gescand-maar-geeft-een-rood-scherm-wat-moet-ik-doen.md
+++ b/_questions-in-app/en/14-mijn-qr-code-is-gescand-maar-geeft-een-rood-scherm-wat-moet-ik-doen.md
@@ -6,8 +6,7 @@ title: My QR code has been scanned but gives a red screen. What do I do?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/15-wat-als-de-app-een-storing-krijgt-als-ik-naar-binnen-wil.md
+++ b/_questions-in-app/en/15-wat-als-de-app-een-storing-krijgt-als-ik-naar-binnen-wil.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/15-wat-als-de-app-een-storing-krijgt-als-ik-naar-binnen-wil.md
+++ b/_questions-in-app/en/15-wat-als-de-app-een-storing-krijgt-als-ik-naar-binnen-wil.md
@@ -6,8 +6,7 @@ title: What if the app doesn't work when I want to get access?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/16-hoe-worden-mijn-gegevens-gebruikt.md
+++ b/_questions-in-app/en/16-hoe-worden-mijn-gegevens-gebruikt.md
@@ -6,8 +6,7 @@ title: What happens to my data?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/16-hoe-worden-mijn-gegevens-gebruikt.md
+++ b/_questions-in-app/en/16-hoe-worden-mijn-gegevens-gebruikt.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/17-wat-ziet-de-controleur-na-scannen-van-mijn-qr-code.md
+++ b/_questions-in-app/en/17-wat-ziet-de-controleur-na-scannen-van-mijn-qr-code.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/17-wat-ziet-de-controleur-na-scannen-van-mijn-qr-code.md
+++ b/_questions-in-app/en/17-wat-ziet-de-controleur-na-scannen-van-mijn-qr-code.md
@@ -6,8 +6,7 @@ title: What does the scanner see after scanning my QR code?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/18-welke-informatie-staat-in-mijn-QR-code.md
+++ b/_questions-in-app/en/18-welke-informatie-staat-in-mijn-QR-code.md
@@ -6,8 +6,7 @@ title: What information does my QR code contain?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/18-welke-informatie-staat-in-mijn-QR-code.md
+++ b/_questions-in-app/en/18-welke-informatie-staat-in-mijn-QR-code.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/2-waarom-ontwikkelt-de-overheid-coronacheck.md
+++ b/_questions-in-app/en/2-waarom-ontwikkelt-de-overheid-coronacheck.md
@@ -6,8 +6,7 @@ title: Why is the government developing the CoronaCheck app?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/2-waarom-ontwikkelt-de-overheid-coronacheck.md
+++ b/_questions-in-app/en/2-waarom-ontwikkelt-de-overheid-coronacheck.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/3-wanneer-zijn-de-apps-klaar-voor-gebruik.md
+++ b/_questions-in-app/en/3-wanneer-zijn-de-apps-klaar-voor-gebruik.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/3-wanneer-zijn-de-apps-klaar-voor-gebruik.md
+++ b/_questions-in-app/en/3-wanneer-zijn-de-apps-klaar-voor-gebruik.md
@@ -6,8 +6,7 @@ title: When are the apps ready to be used?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/4-bij-welke-locaties-heb-ik-coronacheck-nodig.md
+++ b/_questions-in-app/en/4-bij-welke-locaties-heb-ik-coronacheck-nodig.md
@@ -6,8 +6,7 @@ title: Which locations require the CoronaCheck app to get access?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/4-bij-welke-locaties-heb-ik-coronacheck-nodig.md
+++ b/_questions-in-app/en/4-bij-welke-locaties-heb-ik-coronacheck-nodig.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/5-ik-heb-een-QR-code-maar-heb-nu-klachten.md
+++ b/_questions-in-app/en/5-ik-heb-een-QR-code-maar-heb-nu-klachten.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/5-ik-heb-een-QR-code-maar-heb-nu-klachten.md
+++ b/_questions-in-app/en/5-ik-heb-een-QR-code-maar-heb-nu-klachten.md
@@ -6,8 +6,7 @@ title: I have a valid QR code, but I also have symptoms. Can I still get access?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/6-ik-heb-een-negatief-testresultaat-maar-moet-in-quarantaine-van-ggd.md
+++ b/_questions-in-app/en/6-ik-heb-een-negatief-testresultaat-maar-moet-in-quarantaine-van-ggd.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/6-ik-heb-een-negatief-testresultaat-maar-moet-in-quarantaine-van-ggd.md
+++ b/_questions-in-app/en/6-ik-heb-een-negatief-testresultaat-maar-moet-in-quarantaine-van-ggd.md
@@ -6,8 +6,7 @@ title: Despite my negative test result, the GGD orders me to self-isolate. What 
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/7-ik-wil-me-laten-testen-waar-kan-ik-terecht.md
+++ b/_questions-in-app/en/7-ik-wil-me-laten-testen-waar-kan-ik-terecht.md
@@ -6,8 +6,7 @@ title: Where can I get tested?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/7-ik-wil-me-laten-testen-waar-kan-ik-terecht.md
+++ b/_questions-in-app/en/7-ik-wil-me-laten-testen-waar-kan-ik-terecht.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/8-ik-heb-mij-laten-testen-hoe-krijg-ik-mijn-testresultaat.md
+++ b/_questions-in-app/en/8-ik-heb-mij-laten-testen-hoe-krijg-ik-mijn-testresultaat.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/8-ik-heb-mij-laten-testen-hoe-krijg-ik-mijn-testresultaat.md
+++ b/_questions-in-app/en/8-ik-heb-mij-laten-testen-hoe-krijg-ik-mijn-testresultaat.md
@@ -6,8 +6,7 @@ title: I've taken a test, how do I get my results?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/9-hoe-lang-is-mijn-testbewijs-geldig.md
+++ b/_questions-in-app/en/9-hoe-lang-is-mijn-testbewijs-geldig.md
@@ -7,6 +7,7 @@ lang: en
 categories:
 - en
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/en/9-hoe-lang-is-mijn-testbewijs-geldig.md
+++ b/_questions-in-app/en/9-hoe-lang-is-mijn-testbewijs-geldig.md
@@ -6,8 +6,7 @@ title: How long is my test declaration valid?
 lang: en
 categories:
 - en
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/1-hoe-werkt-de-coronacheck-app.md
+++ b/_questions-in-app/nl/1-hoe-werkt-de-coronacheck-app.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/1-hoe-werkt-de-coronacheck-app.md
+++ b/_questions-in-app/nl/1-hoe-werkt-de-coronacheck-app.md
@@ -6,8 +6,7 @@ title: Hoe werkt de CoronaCheck-app?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/10-waarom-is-de-geldigheidsduur-van-een-testbewijs-40-uur.md
+++ b/_questions-in-app/nl/10-waarom-is-de-geldigheidsduur-van-een-testbewijs-40-uur.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/10-waarom-is-de-geldigheidsduur-van-een-testbewijs-40-uur.md
+++ b/_questions-in-app/nl/10-waarom-is-de-geldigheidsduur-van-een-testbewijs-40-uur.md
@@ -6,8 +6,7 @@ title: Waarom is de geldigheidsduur van een testbewijs 40 uur?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/11-werkt-coronacheck-op-mijn-telefoon.md
+++ b/_questions-in-app/nl/11-werkt-coronacheck-op-mijn-telefoon.md
@@ -6,8 +6,7 @@ title: Werkt CoronaCheck op mijn telefoon?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/11-werkt-coronacheck-op-mijn-telefoon.md
+++ b/_questions-in-app/nl/11-werkt-coronacheck-op-mijn-telefoon.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/12-kan-ik-coronacheck-ook-gebruiken-in-het-buitenland.md
+++ b/_questions-in-app/nl/12-kan-ik-coronacheck-ook-gebruiken-in-het-buitenland.md
@@ -6,8 +6,7 @@ title: Kan ik CoronaCheck ook gebruiken in het buitenland?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/12-kan-ik-coronacheck-ook-gebruiken-in-het-buitenland.md
+++ b/_questions-in-app/nl/12-kan-ik-coronacheck-ook-gebruiken-in-het-buitenland.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/13-de-app-zegt-dat-er-geen-negatief-testresultaat-gevonden-is-hoe-kan-dit.md
+++ b/_questions-in-app/nl/13-de-app-zegt-dat-er-geen-negatief-testresultaat-gevonden-is-hoe-kan-dit.md
@@ -6,8 +6,7 @@ title: De app zegt dat er geen negatieve testuitslag gevonden is. Hoe kan dit?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 published: false

--- a/_questions-in-app/nl/13-de-app-zegt-dat-er-geen-negatief-testresultaat-gevonden-is-hoe-kan-dit.md
+++ b/_questions-in-app/nl/13-de-app-zegt-dat-er-geen-negatief-testresultaat-gevonden-is-hoe-kan-dit.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 published: false

--- a/_questions-in-app/nl/14-mijn-qr-code-is-gescand-maar-geeft-een-rood-scherm-wat-moet-ik-doen.md
+++ b/_questions-in-app/nl/14-mijn-qr-code-is-gescand-maar-geeft-een-rood-scherm-wat-moet-ik-doen.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/14-mijn-qr-code-is-gescand-maar-geeft-een-rood-scherm-wat-moet-ik-doen.md
+++ b/_questions-in-app/nl/14-mijn-qr-code-is-gescand-maar-geeft-een-rood-scherm-wat-moet-ik-doen.md
@@ -6,8 +6,7 @@ title: Mijn QR-code is gescand, maar geeft een rood scherm. Wat moet ik doen?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/15-wat-als-de-app-een-storing-krijgt-als-ik-naar-binnen-wil.md
+++ b/_questions-in-app/nl/15-wat-als-de-app-een-storing-krijgt-als-ik-naar-binnen-wil.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/15-wat-als-de-app-een-storing-krijgt-als-ik-naar-binnen-wil.md
+++ b/_questions-in-app/nl/15-wat-als-de-app-een-storing-krijgt-als-ik-naar-binnen-wil.md
@@ -6,8 +6,7 @@ title: Wat als de app een storing krijgt als ik naar binnen wil?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/16-hoe-worden-mijn-gegevens-gebruikt.md
+++ b/_questions-in-app/nl/16-hoe-worden-mijn-gegevens-gebruikt.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/16-hoe-worden-mijn-gegevens-gebruikt.md
+++ b/_questions-in-app/nl/16-hoe-worden-mijn-gegevens-gebruikt.md
@@ -6,8 +6,7 @@ title: Hoe worden mijn gegevens gebruikt?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/17-wat-ziet-de-controleur-na-scannen-van-mijn-qr-code.md
+++ b/_questions-in-app/nl/17-wat-ziet-de-controleur-na-scannen-van-mijn-qr-code.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/17-wat-ziet-de-controleur-na-scannen-van-mijn-qr-code.md
+++ b/_questions-in-app/nl/17-wat-ziet-de-controleur-na-scannen-van-mijn-qr-code.md
@@ -6,8 +6,7 @@ title: Wat ziet de controleur na het scannen van mijn QR-code?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/18-welke-informatie-staat-in-mijn-QR-code.md
+++ b/_questions-in-app/nl/18-welke-informatie-staat-in-mijn-QR-code.md
@@ -6,8 +6,7 @@ title: Welke informatie staat in mijn QR-code?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/18-welke-informatie-staat-in-mijn-QR-code.md
+++ b/_questions-in-app/nl/18-welke-informatie-staat-in-mijn-QR-code.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/19-ik-heb-geen-smartphone-kan-ik-wel-een-testbewijs-krijgen.md
+++ b/_questions-in-app/nl/19-ik-heb-geen-smartphone-kan-ik-wel-een-testbewijs-krijgen.md
@@ -6,8 +6,7 @@ title: Ik heb geen smartphone. Kan ik wel een testbewijs krijgen?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/19-ik-heb-geen-smartphone-kan-ik-wel-een-testbewijs-krijgen.md
+++ b/_questions-in-app/nl/19-ik-heb-geen-smartphone-kan-ik-wel-een-testbewijs-krijgen.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/2-waarom-ontwikkelt-de-overheid-coronacheck.md
+++ b/_questions-in-app/nl/2-waarom-ontwikkelt-de-overheid-coronacheck.md
@@ -6,8 +6,7 @@ title: Waarom ontwikkelt de overheid de CoronaCheck-app?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/2-waarom-ontwikkelt-de-overheid-coronacheck.md
+++ b/_questions-in-app/nl/2-waarom-ontwikkelt-de-overheid-coronacheck.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/20-kan-mijn-testbewijs-meerdere-keren-gescand-worden.md
+++ b/_questions-in-app/nl/20-kan-mijn-testbewijs-meerdere-keren-gescand-worden.md
@@ -6,8 +6,7 @@ title: Kan mijn testbewijs meerdere keren gescand worden?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/20-kan-mijn-testbewijs-meerdere-keren-gescand-worden.md
+++ b/_questions-in-app/nl/20-kan-mijn-testbewijs-meerdere-keren-gescand-worden.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/21-vanaf-welke-leeftijd-is-een-testbewijs-nodig.md
+++ b/_questions-in-app/nl/21-vanaf-welke-leeftijd-is-een-testbewijs-nodig.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/21-vanaf-welke-leeftijd-is-een-testbewijs-nodig.md
+++ b/_questions-in-app/nl/21-vanaf-welke-leeftijd-is-een-testbewijs-nodig.md
@@ -6,8 +6,7 @@ title: Vanaf welke leeftijd is een testbewijs nodig?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/22-kan-ik-een-testbewijs-voor-iemand-anders-in-mijn-app-toevoegen.md
+++ b/_questions-in-app/nl/22-kan-ik-een-testbewijs-voor-iemand-anders-in-mijn-app-toevoegen.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/22-kan-ik-een-testbewijs-voor-iemand-anders-in-mijn-app-toevoegen.md
+++ b/_questions-in-app/nl/22-kan-ik-een-testbewijs-voor-iemand-anders-in-mijn-app-toevoegen.md
@@ -6,8 +6,7 @@ title: Kan ik een testbewijs voor iemand anders in mijn CoronaCheck-app toevoege
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/3-wanneer-zijn-de-apps-klaar-voor-gebruik.md
+++ b/_questions-in-app/nl/3-wanneer-zijn-de-apps-klaar-voor-gebruik.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/3-wanneer-zijn-de-apps-klaar-voor-gebruik.md
+++ b/_questions-in-app/nl/3-wanneer-zijn-de-apps-klaar-voor-gebruik.md
@@ -6,8 +6,7 @@ title: Wanneer zijn de apps klaar voor gebruik?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/30-onderzoek-hoe-weten-we-of-coronacheck-werkt.md
+++ b/_questions-in-app/nl/30-onderzoek-hoe-weten-we-of-coronacheck-werkt.md
@@ -6,8 +6,7 @@ title: "Onderzoek: hoe weten we of CoronaCheck werkt?"
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/30-onderzoek-hoe-weten-we-of-coronacheck-werkt.md
+++ b/_questions-in-app/nl/30-onderzoek-hoe-weten-we-of-coronacheck-werkt.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/4-bij-welke-locaties-heb-ik-coronacheck-nodig.md
+++ b/_questions-in-app/nl/4-bij-welke-locaties-heb-ik-coronacheck-nodig.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/4-bij-welke-locaties-heb-ik-coronacheck-nodig.md
+++ b/_questions-in-app/nl/4-bij-welke-locaties-heb-ik-coronacheck-nodig.md
@@ -6,8 +6,7 @@ title: Bij welke locaties heb ik CoronaCheck nodig als ik naar binnen wil?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/4-bij-welke-locaties-is-een-testbewijs-nodig.md
+++ b/_questions-in-app/nl/4-bij-welke-locaties-is-een-testbewijs-nodig.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/4-bij-welke-locaties-is-een-testbewijs-nodig.md
+++ b/_questions-in-app/nl/4-bij-welke-locaties-is-een-testbewijs-nodig.md
@@ -6,8 +6,7 @@ title: Bij welke locaties is een testbewijs nodig als ik naar binnen wil?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/5-ik-heb-een-QR-code-maar-heb-nu-klachten.md
+++ b/_questions-in-app/nl/5-ik-heb-een-QR-code-maar-heb-nu-klachten.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/5-ik-heb-een-QR-code-maar-heb-nu-klachten.md
+++ b/_questions-in-app/nl/5-ik-heb-een-QR-code-maar-heb-nu-klachten.md
@@ -6,8 +6,7 @@ title: Ik heb een QR-code, maar heb nu klachten. Mag ik alsnog naar binnen?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/6-ik-heb-een-negatief-testresultaat-maar-moet-in-quarantaine-van-ggd.md
+++ b/_questions-in-app/nl/6-ik-heb-een-negatief-testresultaat-maar-moet-in-quarantaine-van-ggd.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/6-ik-heb-een-negatief-testresultaat-maar-moet-in-quarantaine-van-ggd.md
+++ b/_questions-in-app/nl/6-ik-heb-een-negatief-testresultaat-maar-moet-in-quarantaine-van-ggd.md
@@ -6,8 +6,7 @@ title: Ik heb een negatieve uitslag, maar moet in quarantaine blijven van de GGD
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/7-ik-wil-me-laten-testen-waar-kan-ik-terecht.md
+++ b/_questions-in-app/nl/7-ik-wil-me-laten-testen-waar-kan-ik-terecht.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/7-ik-wil-me-laten-testen-waar-kan-ik-terecht.md
+++ b/_questions-in-app/nl/7-ik-wil-me-laten-testen-waar-kan-ik-terecht.md
@@ -6,8 +6,7 @@ title: Ik wil me laten testen, waar kan ik terecht?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/8-ik-heb-mij-laten-testen-hoe-krijg-ik-mijn-testresultaat.md
+++ b/_questions-in-app/nl/8-ik-heb-mij-laten-testen-hoe-krijg-ik-mijn-testresultaat.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/8-ik-heb-mij-laten-testen-hoe-krijg-ik-mijn-testresultaat.md
+++ b/_questions-in-app/nl/8-ik-heb-mij-laten-testen-hoe-krijg-ik-mijn-testresultaat.md
@@ -6,8 +6,7 @@ title: Ik heb mij laten testen, hoe krijg ik mijn testuitslag?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/9-hoe-lang-is-mijn-testbewijs-geldig.md
+++ b/_questions-in-app/nl/9-hoe-lang-is-mijn-testbewijs-geldig.md
@@ -7,6 +7,7 @@ lang: nl
 categories:
 - nl
 - faq
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-in-app/nl/9-hoe-lang-is-mijn-testbewijs-geldig.md
+++ b/_questions-in-app/nl/9-hoe-lang-is-mijn-testbewijs-geldig.md
@@ -6,8 +6,7 @@ title: Hoe lang is mijn testbewijs geldig?
 lang: nl
 categories:
 - nl
-- faq
-- in-app
+- faq-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/1-waarom-ontwikkelt-de-overheid-coronacheck-scanner.md
+++ b/_questions-scanner-in-app/en/1-waarom-ontwikkelt-de-overheid-coronacheck-scanner.md
@@ -6,8 +6,7 @@ title: Why is the government developing the CoronaCheck Scanner?
 lang: en
 categories:
 - en
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/1-waarom-ontwikkelt-de-overheid-coronacheck-scanner.md
+++ b/_questions-scanner-in-app/en/1-waarom-ontwikkelt-de-overheid-coronacheck-scanner.md
@@ -6,7 +6,8 @@ title: Why is the government developing the CoronaCheck Scanner?
 lang: en
 categories:
 - en
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/2-wanneer-zijn-de-apps-klaar-voor-gebruik.md
+++ b/_questions-scanner-in-app/en/2-wanneer-zijn-de-apps-klaar-voor-gebruik.md
@@ -6,8 +6,7 @@ title: When are the apps ready to be used? 
 lang: en
 categories:
 - en
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/2-wanneer-zijn-de-apps-klaar-voor-gebruik.md
+++ b/_questions-scanner-in-app/en/2-wanneer-zijn-de-apps-klaar-voor-gebruik.md
@@ -6,7 +6,8 @@ title: When are the apps ready to be used? 
 lang: en
 categories:
 - en
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/3-hoe-werkt-het-scannen-met-de-coronacheck-scanner.md
+++ b/_questions-scanner-in-app/en/3-hoe-werkt-het-scannen-met-de-coronacheck-scanner.md
@@ -6,8 +6,7 @@ title: How does the CoronaCheck Scanner work?
 lang: en
 categories:
 - en
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/3-hoe-werkt-het-scannen-met-de-coronacheck-scanner.md
+++ b/_questions-scanner-in-app/en/3-hoe-werkt-het-scannen-met-de-coronacheck-scanner.md
@@ -6,7 +6,8 @@ title: How does the CoronaCheck Scanner work?
 lang: en
 categories:
 - en
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/4-mag-ik-iemand-zonder-geldig-testbewijs-in-de-coronacheck-app-binnen-laten.md
+++ b/_questions-scanner-in-app/en/4-mag-ik-iemand-zonder-geldig-testbewijs-in-de-coronacheck-app-binnen-laten.md
@@ -6,8 +6,7 @@ title: Can I allow a visitor access without a valid test declaration in the Coro
 lang: en
 categories:
 - en
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/4-mag-ik-iemand-zonder-geldig-testbewijs-in-de-coronacheck-app-binnen-laten.md
+++ b/_questions-scanner-in-app/en/4-mag-ik-iemand-zonder-geldig-testbewijs-in-de-coronacheck-app-binnen-laten.md
@@ -6,7 +6,8 @@ title: Can I allow a visitor access without a valid test declaration in the Coro
 lang: en
 categories:
 - en
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/5-werkt-de-app-ook-als-ik-offline-ben.md
+++ b/_questions-scanner-in-app/en/5-werkt-de-app-ook-als-ik-offline-ben.md
@@ -6,8 +6,7 @@ title: Does the app work without internet connection?
 lang: en
 categories:
 - en
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/5-werkt-de-app-ook-als-ik-offline-ben.md
+++ b/_questions-scanner-in-app/en/5-werkt-de-app-ook-als-ik-offline-ben.md
@@ -6,7 +6,8 @@ title: Does the app work without internet connection?
 lang: en
 categories:
 - en
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/6-wat-als-mijn-scanner-plotseling-niet-werkt.md
+++ b/_questions-scanner-in-app/en/6-wat-als-mijn-scanner-plotseling-niet-werkt.md
@@ -6,7 +6,8 @@ title: What if my scanner suddenly doesn't work?
 lang: en
 categories:
 - en
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/6-wat-als-mijn-scanner-plotseling-niet-werkt.md
+++ b/_questions-scanner-in-app/en/6-wat-als-mijn-scanner-plotseling-niet-werkt.md
@@ -6,8 +6,7 @@ title: What if my scanner suddenly doesn't work?
 lang: en
 categories:
 - en
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/7-na-scannen-een-rood-scherm-wat-nu.md
+++ b/_questions-scanner-in-app/en/7-na-scannen-een-rood-scherm-wat-nu.md
@@ -6,7 +6,8 @@ title: I get a red screen after scanning a QR code. What now?
 lang: en
 categories:
 - en
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/7-na-scannen-een-rood-scherm-wat-nu.md
+++ b/_questions-scanner-in-app/en/7-na-scannen-een-rood-scherm-wat-nu.md
@@ -6,8 +6,7 @@ title: I get a red screen after scanning a QR code. What now?
 lang: en
 categories:
 - en
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/8-welke-gegevens-worden-door-coronacheck-scanner-verwerkt-en-opgeslagen.md
+++ b/_questions-scanner-in-app/en/8-welke-gegevens-worden-door-coronacheck-scanner-verwerkt-en-opgeslagen.md
@@ -6,7 +6,8 @@ title: What data is processed and saved by the CoronaCheck scanner?
 lang: en
 categories:
 - en
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/en/8-welke-gegevens-worden-door-coronacheck-scanner-verwerkt-en-opgeslagen.md
+++ b/_questions-scanner-in-app/en/8-welke-gegevens-worden-door-coronacheck-scanner-verwerkt-en-opgeslagen.md
@@ -6,8 +6,7 @@ title: What data is processed and saved by the CoronaCheck scanner?
 lang: en
 categories:
 - en
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/1-waarom-ontwikkelt-de-overheid-coronacheck-scanner.md
+++ b/_questions-scanner-in-app/nl/1-waarom-ontwikkelt-de-overheid-coronacheck-scanner.md
@@ -6,7 +6,8 @@ title: Waarom ontwikkelt de overheid CoronaCheck Scanner?
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/1-waarom-ontwikkelt-de-overheid-coronacheck-scanner.md
+++ b/_questions-scanner-in-app/nl/1-waarom-ontwikkelt-de-overheid-coronacheck-scanner.md
@@ -6,8 +6,7 @@ title: Waarom ontwikkelt de overheid CoronaCheck Scanner?
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/10-bij-welke-locaties-is-een-testbewijs-nodig-als-bezoekers-naar-binnen-willen.md
+++ b/_questions-scanner-in-app/nl/10-bij-welke-locaties-is-een-testbewijs-nodig-als-bezoekers-naar-binnen-willen.md
@@ -6,8 +6,7 @@ title: Bij welke locaties is een testbewijs nodig als bezoekers naar binnen will
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/10-bij-welke-locaties-is-een-testbewijs-nodig-als-bezoekers-naar-binnen-willen.md
+++ b/_questions-scanner-in-app/nl/10-bij-welke-locaties-is-een-testbewijs-nodig-als-bezoekers-naar-binnen-willen.md
@@ -6,7 +6,8 @@ title: Bij welke locaties is een testbewijs nodig als bezoekers naar binnen will
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/11-kan-het-testbewijs-meerdere-keren-gescand-worden.md
+++ b/_questions-scanner-in-app/nl/11-kan-het-testbewijs-meerdere-keren-gescand-worden.md
@@ -6,7 +6,8 @@ title: Kan het testbewijs meerdere keren gescand worden?
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/11-kan-het-testbewijs-meerdere-keren-gescand-worden.md
+++ b/_questions-scanner-in-app/nl/11-kan-het-testbewijs-meerdere-keren-gescand-worden.md
@@ -6,8 +6,7 @@ title: Kan het testbewijs meerdere keren gescand worden?
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/12-vanaf-welke-leeftijd-is-een-testbewijs-nodig.md
+++ b/_questions-scanner-in-app/nl/12-vanaf-welke-leeftijd-is-een-testbewijs-nodig.md
@@ -6,7 +6,8 @@ title: Vanaf welke leeftijd is een testbewijs nodig?
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/12-vanaf-welke-leeftijd-is-een-testbewijs-nodig.md
+++ b/_questions-scanner-in-app/nl/12-vanaf-welke-leeftijd-is-een-testbewijs-nodig.md
@@ -6,8 +6,7 @@ title: Vanaf welke leeftijd is een testbewijs nodig?
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/2-wanneer-zijn-de-apps-klaar-voor-gebruik.md
+++ b/_questions-scanner-in-app/nl/2-wanneer-zijn-de-apps-klaar-voor-gebruik.md
@@ -6,7 +6,8 @@ title: Wanneer zijn de apps klaar voor gebruik?
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/2-wanneer-zijn-de-apps-klaar-voor-gebruik.md
+++ b/_questions-scanner-in-app/nl/2-wanneer-zijn-de-apps-klaar-voor-gebruik.md
@@ -6,8 +6,7 @@ title: Wanneer zijn de apps klaar voor gebruik?
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/3-hoe-werkt-het-scannen-met-de-coronacheck-scanner.md
+++ b/_questions-scanner-in-app/nl/3-hoe-werkt-het-scannen-met-de-coronacheck-scanner.md
@@ -6,8 +6,7 @@ title: Hoe werkt het scannen met de CoronaCheck Scanner?
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/3-hoe-werkt-het-scannen-met-de-coronacheck-scanner.md
+++ b/_questions-scanner-in-app/nl/3-hoe-werkt-het-scannen-met-de-coronacheck-scanner.md
@@ -6,7 +6,8 @@ title: Hoe werkt het scannen met de CoronaCheck Scanner?
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/4-mag-ik-iemand-zonder-geldig-testbewijs-binnen-laten.md
+++ b/_questions-scanner-in-app/nl/4-mag-ik-iemand-zonder-geldig-testbewijs-binnen-laten.md
@@ -6,8 +6,7 @@ title: Mag ik iemand zonder geldig testbewijs binnen laten?
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/4-mag-ik-iemand-zonder-geldig-testbewijs-binnen-laten.md
+++ b/_questions-scanner-in-app/nl/4-mag-ik-iemand-zonder-geldig-testbewijs-binnen-laten.md
@@ -6,7 +6,8 @@ title: Mag ik iemand zonder geldig testbewijs binnen laten?
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/5-werkt-de-app-ook-als-ik-offline-ben.md
+++ b/_questions-scanner-in-app/nl/5-werkt-de-app-ook-als-ik-offline-ben.md
@@ -6,8 +6,7 @@ title: Werkt de app ook als ik offline ben?
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/5-werkt-de-app-ook-als-ik-offline-ben.md
+++ b/_questions-scanner-in-app/nl/5-werkt-de-app-ook-als-ik-offline-ben.md
@@ -6,7 +6,8 @@ title: Werkt de app ook als ik offline ben?
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/6-wat-als-mijn-scanner-plotseling-niet-werkt.md
+++ b/_questions-scanner-in-app/nl/6-wat-als-mijn-scanner-plotseling-niet-werkt.md
@@ -6,7 +6,8 @@ title: Wat als mijn scanner plotseling niet werkt?
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/6-wat-als-mijn-scanner-plotseling-niet-werkt.md
+++ b/_questions-scanner-in-app/nl/6-wat-als-mijn-scanner-plotseling-niet-werkt.md
@@ -6,8 +6,7 @@ title: Wat als mijn scanner plotseling niet werkt?
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/7-na-scannen-een-rood-scherm-wat-nu.md
+++ b/_questions-scanner-in-app/nl/7-na-scannen-een-rood-scherm-wat-nu.md
@@ -6,8 +6,7 @@ title: Ik krijg na het scannen van een QR-code een rood scherm te zien, wat nu?
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/7-na-scannen-een-rood-scherm-wat-nu.md
+++ b/_questions-scanner-in-app/nl/7-na-scannen-een-rood-scherm-wat-nu.md
@@ -6,7 +6,8 @@ title: Ik krijg na het scannen van een QR-code een rood scherm te zien, wat nu?
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/8-welke-gegevens-worden-door-coronacheck-scanner-verwerkt-en-opgeslagen.md
+++ b/_questions-scanner-in-app/nl/8-welke-gegevens-worden-door-coronacheck-scanner-verwerkt-en-opgeslagen.md
@@ -6,8 +6,7 @@ title: Welke gegevens worden door CoronaCheck Scanner verwerkt en opgeslagen?
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/8-welke-gegevens-worden-door-coronacheck-scanner-verwerkt-en-opgeslagen.md
+++ b/_questions-scanner-in-app/nl/8-welke-gegevens-worden-door-coronacheck-scanner-verwerkt-en-opgeslagen.md
@@ -6,7 +6,8 @@ title: Welke gegevens worden door CoronaCheck Scanner verwerkt en opgeslagen?
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/9-werkt-coronacheck-scanner-op-mijn-telefoon.md
+++ b/_questions-scanner-in-app/nl/9-werkt-coronacheck-scanner-op-mijn-telefoon.md
@@ -6,7 +6,8 @@ title: Werkt CoronaCheck Scanner op mijn telefoon?
 lang: nl
 categories:
 - nl
-- faq
+- faq-scanner
+- in-app
 showBreadCrumbs: true
 showContact: true
 ---

--- a/_questions-scanner-in-app/nl/9-werkt-coronacheck-scanner-op-mijn-telefoon.md
+++ b/_questions-scanner-in-app/nl/9-werkt-coronacheck-scanner-op-mijn-telefoon.md
@@ -6,8 +6,7 @@ title: Werkt CoronaCheck Scanner op mijn telefoon?
 lang: nl
 categories:
 - nl
-- faq-scanner
-- in-app
+- faq-scanner-in-app
 showBreadCrumbs: true
 showContact: true
 ---


### PR DESCRIPTION
Fixes heading order in privacy statements and fixes issue with breadcrumb of in-app-questions, which showed the question (page title) three times, and linked back to Home. it now links back to Meergestelde vragen and only shows the question (page title) once.