### PR TITLE
Translations: event --> evenement

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -104,7 +104,7 @@ header-skip-to-content:
   tr: Doğrudan içeriğe gidin
     
 header-title:
-  nl: Ga naar een event met de CoronaCheck-app
+  nl: Ga naar een evenement met de CoronaCheck-app
   fy: CoronaCheck
   en: CoronaCheck
   ar: CoronaCheck


### PR DESCRIPTION
Since _event_ isn't a Dutch word, I propose to change it to _evenement_.

New home page looks great btw!