### PR TITLE
Cleanup open-source comment

### DIFF
--- a/_includes/open-source-comment.html
+++ b/_includes/open-source-comment.html
@@ -1,0 +1,5 @@
+<!--
+  This website is generated at {{ site.time }}.
+  The code is open source. You are welcome to contribute. Go to:
+  https://github.com/minvws/nl-covid19-coronacheck-website
+-->

--- a/_layouts/content-error.html
+++ b/_layouts/content-error.html
@@ -3,8 +3,6 @@
 {%- if page.lang -%}
   {%- assign langSlug = site.baseurl | append: '/' | append: page.lang -%}
 {%- endif -%}
-
-
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
 {% include open-source-comment.html %}

--- a/_layouts/content-error.html
+++ b/_layouts/content-error.html
@@ -7,11 +7,7 @@
 
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
-<!--
-  This website is generated at {{ site.time }}.
-  The code is open source. You are welcome to contribute. Go to git: 
-  https://github.com/minvws/nl-covid19-coronacheck-website
--->
+{% include open-source-comment.html %}
 {% include head.html %}
 <body>
   <div class="logobar" role="banner">

--- a/_layouts/content-pilot.html
+++ b/_layouts/content-pilot.html
@@ -3,7 +3,6 @@
 {%- if page.lang -%}
   {%- assign langSlug = site.baseurl | append: '/' | append: page.lang -%}
 {%- endif -%}
-
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
 {% include open-source-comment.html %}

--- a/_layouts/content-pilot.html
+++ b/_layouts/content-pilot.html
@@ -6,11 +6,7 @@
 
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
-<!--
-  This website is generated at {{ site.time }}.
-  The code is open source. You are welcome to contribute. Go to git: 
-  https://github.com/minvws/nl-covid19-coronacheck-website
--->
+{% include open-source-comment.html %}
 {% include head.html %}
 <body>
   {% include header-slim.html %}

--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -3,7 +3,6 @@
 {%- if page.lang -%}
   {%- assign langSlug = site.baseurl | append: '/' | append: page.lang -%}
 {%- endif -%}
-
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
 {% include open-source-comment.html %}

--- a/_layouts/content.html
+++ b/_layouts/content.html
@@ -6,11 +6,7 @@
 
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
-<!--
-  This website is generated at {{ site.time }}.
-  The code is open source. You are welcome to contribute. Go to git: 
-  https://github.com/minvws/nl-covid19-coronacheck-website
--->
+{% include open-source-comment.html %}
 {% include head.html %}
 <body>
   {% if page.collection == 'questions-scanner' or page.domain == 'scanner' %}

--- a/_layouts/faq-overview.html
+++ b/_layouts/faq-overview.html
@@ -3,7 +3,6 @@
 {%- if page.lang -%}
   {%- assign langSlug = site.baseurl | append: '/' | append: page.lang -%}
 {%- endif -%}
-
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
 {% include open-source-comment.html %}

--- a/_layouts/faq-overview.html
+++ b/_layouts/faq-overview.html
@@ -6,11 +6,7 @@
 
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
-<!--
-  This website is generated at {{ site.time }}.
-  The code is open source. You are welcome to contribute. Go to git: 
-  https://github.com/minvws/nl-covid19-coronacheck-website
--->
+{% include open-source-comment.html %}
 {% include head.html %}
 <body>
   {% include header-slim.html %}

--- a/_layouts/faq-scanner-overview.html
+++ b/_layouts/faq-scanner-overview.html
@@ -3,7 +3,6 @@
 {%- if page.lang -%}
   {%- assign langSlug = site.baseurl | append: '/' | append: page.lang -%}
 {%- endif -%}
-
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
 {% include open-source-comment.html %}

--- a/_layouts/faq-scanner-overview.html
+++ b/_layouts/faq-scanner-overview.html
@@ -6,11 +6,7 @@
 
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
-<!--
-  This website is generated at {{ site.time }}.
-  The code is open source. You are welcome to contribute. Go to git: 
-  https://github.com/minvws/nl-covid19-coronacheck-website
--->
+{% include open-source-comment.html %}
 {% include head.html %}
 <body>
   {% include header-slim.html for="scanner" %}

--- a/_layouts/home-scanner.html
+++ b/_layouts/home-scanner.html
@@ -3,8 +3,6 @@
 {%- if page.lang -%}
   {%- assign langSlug = site.baseurl | append: '/' | append: page.lang -%}
 {%- endif -%}
-
-
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
 {% include open-source-comment.html %}

--- a/_layouts/home-scanner.html
+++ b/_layouts/home-scanner.html
@@ -6,12 +6,8 @@
 
 
 <!DOCTYPE html>
-<!--
-  This website is generated at {{ site.time }}.
-  The code is open source. You are welcome to contribute. Go to git: 
-  https://github.com/minvws/nl-covid19-coronacheck-website
--->
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
+{% include open-source-comment.html %}
 {% include head.html for="scanner" %}
 <body>
   {% include header.html for="scanner" %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,7 +3,6 @@
 {%- if page.lang -%}
   {%- assign langSlug = site.baseurl | append: '/' | append: page.lang -%}
 {%- endif -%}
-
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
 {% include open-source-comment.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,12 +5,8 @@
 {%- endif -%}
 
 <!DOCTYPE html>
-<!--
-  This website is generated at {{ site.time }}.
-  The code is open source. You are welcome to contribute. Go to git: 
-  https://github.com/minvws/nl-covid19-coronacheck-website
--->
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
+{% include open-source-comment.html %}
 {% include head.html %}
 <body>
   {% include header.html %}

--- a/_layouts/in-app-content.html
+++ b/_layouts/in-app-content.html
@@ -7,12 +7,7 @@
 
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
-<!--
-  This website is generated at {{ site.time }}.
-  The code is open source. You are welcome to contribute. Go to git: 
-  https://github.com/minvws/nl-covid19-coronacheck-website
--->
-
+{% include open-source-comment.html %}
 {% if page.collection == 'questions-scanner-in-app' or page.domain == 'scanner' %}
   {% include head.html for="scanner" in-app="true" %}
 {% else %}

--- a/_layouts/in-app-content.html
+++ b/_layouts/in-app-content.html
@@ -3,8 +3,6 @@
 {%- if page.lang -%}
   {%- assign langSlug = site.baseurl | append: '/' | append: page.lang -%}
 {%- endif -%}
-
-
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
 {% include open-source-comment.html %}
@@ -13,7 +11,6 @@
 {% else %}
   {% include head.html in-app="true" %}
 {% endif %}
-
 <body>
   <main class="content-center content-center__in_app" id="content">
     <div class="content-block" {% if page.contentLang == 'en' %}lang="en" dir="ltr"{% elsif page.contentLang == 'nl' %}lang="nl"{% endif %}>

--- a/_layouts/in-app-faq.html
+++ b/_layouts/in-app-faq.html
@@ -3,9 +3,6 @@
 {%- if page.lang -%}
   {%- assign langSlug = site.baseurl | append: '/' | append: page.lang -%}
 {%- endif -%}
-
-
-
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
 {% include open-source-comment.html %}
@@ -14,7 +11,6 @@
 {% else %}
   {% include head.html in-app="true" %}
 {% endif %}
-
 <body>
   <main class="content-center content-center__in_app" id="content">
     <div class="content-block">

--- a/_layouts/in-app-faq.html
+++ b/_layouts/in-app-faq.html
@@ -8,11 +8,7 @@
 
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
-<!--
-  This website is generated at {{ site.time }}.
-  The code is open source. You are welcome to contribute. Go to git: 
-  https://github.com/minvws/nl-covid19-coronacheck-website
--->
+{% include open-source-comment.html %}
 {% if page.collection == 'questions-scanner-in-app' or page.domain == 'scanner' %}
   {% include head.html for="scanner" in-app="true" %}
 {% else %}

--- a/_layouts/in-app-question.html
+++ b/_layouts/in-app-question.html
@@ -7,12 +7,7 @@
 
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
-<!--
-  This website is generated at {{ site.time }}.
-  The code is open source. You are welcome to contribute. Go to git: 
-  https://github.com/minvws/nl-covid19-coronacheck-website
--->
-
+{% include open-source-comment.html %}
 {% if page.collection == 'questions-scanner-in-app' or page.domain == 'scanner' %}
   {% include head.html for="scanner" in-app="true" %}
 {% else %}

--- a/_layouts/in-app-question.html
+++ b/_layouts/in-app-question.html
@@ -3,8 +3,6 @@
 {%- if page.lang -%}
   {%- assign langSlug = site.baseurl | append: '/' | append: page.lang -%}
 {%- endif -%}
-
-
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
 {% include open-source-comment.html %}
@@ -13,8 +11,6 @@
 {% else %}
   {% include head.html in-app="true" %}
 {% endif %}
-
-
 <body>
   <main class="content-center content-center__in_app" id="content">
     {% if page.showBreadCrumbs %}

--- a/_layouts/in-app-scanner-faq.html
+++ b/_layouts/in-app-scanner-faq.html
@@ -6,12 +6,7 @@
 
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
-<!--
-  This website is generated at {{ site.time }}.
-  The code is open source. You are welcome to contribute. Go to git: 
-  https://github.com/minvws/nl-covid19-coronacheck-website
--->
-
+{% include open-source-comment.html %}
 {% if page.collection == 'questions-scanner-in-app' or page.domain == 'scanner' %}
   {% include head.html for="scanner" in-app="true" %}
 {% else %}

--- a/_layouts/in-app-scanner-faq.html
+++ b/_layouts/in-app-scanner-faq.html
@@ -3,7 +3,6 @@
 {%- if page.lang -%}
   {%- assign langSlug = site.baseurl | append: '/' | append: page.lang -%}
 {%- endif -%}
-
 <!DOCTYPE html>
 <html lang="{{page.lang}}" {% if page.lang == 'ar' %}dir="rtl"{% endif %}>
 {% include open-source-comment.html %}
@@ -12,7 +11,6 @@
 {% else %}
   {% include head.html in-app="true" %}
 {% endif %}
-
 <body>
   <main class="content-center content-center__in_app" id="content">
     <div class="content-block">


### PR DESCRIPTION
Ahoy!

When I looked at the page-source of the Corona Check website, I noticed the open-source comment:

```html
<!--
  This website is generated at 2021-06-24 11:21:14 +0000.
  The code is open source. You are welcome to contribute. Go to git: 
  https://github.com/minvws/nl-covid19-coronacheck-website
-->
```

So, being curious,  I visited GitHub and had a look at where the comment comes from.

In the code I noticed that the comment was not [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) but repeated across the various Jekyll layout files.

This merge request resolves that by placing the comment in a separate include file.

Besides that, these changes are also made:

- The placement of the comment has been made consistent across layouts (always after the `<html>` tag)
- The white-space around the comment has been made consistent across layouts
- The wording has been changed from `Go to git: ` to `Go to:`, as _technically_ the link does not go to Git but GitHub. (And changing it to `Go to GitHub:` seemed needlessly verbose).

The comment **has not** been added to [`print-portal/public/index.html`](https://github.com/minvws/nl-covid19-coronacheck-website/blob/main/print-portal/public/index.html) as I was not certain that content was also meant to be parsed by Jekyll (both now and in the future).

The result can be seen functioning at: https://contrib.pother.ca/nl-covid19-coronacheck-website/